### PR TITLE
Using Jimp instead of Paper.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     packages:
       - build-essential
       - g++-4.9
-
 language: node_js
 matrix:
   include:
@@ -27,5 +26,3 @@ matrix:
     - env: CXX=g++-4.9
       node_js: '4'
       os: osx
-
-install: travis_wait mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,3 @@ matrix:
       os: osx
     - node_js: '5'
       os: osx
-    - node_js: '4'
-      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 addons:
   apt:
     sources:
@@ -7,9 +5,6 @@ addons:
     packages:
       - build-essential
       - g++-4.9
-      - libssl-dev
-      - libjpeg62-dev
-      - libgif-dev
       - pkg-config
 
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ addons:
     packages:
       - build-essential
       - g++-4.9
-      - libcairo2-dev
-      - libpango1.0-dev
       - libssl-dev
       - libjpeg62-dev
       - libgif-dev
@@ -35,8 +33,3 @@ matrix:
     - env: CXX=g++-4.9
       node_js: '4'
       os: osx
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update               ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo pango  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm install canvas      ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     packages:
       - build-essential
       - g++-4.9
-      - pkg-config
 
 language: node_js
 matrix:
@@ -28,3 +27,5 @@ matrix:
     - env: CXX=g++-4.9
       node_js: '4'
       os: osx
+
+install: travis_wait mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - build-essential
-      - g++-4.9
 language: node_js
 matrix:
   include:
-    - env: CXX=g++-4.9
-      node_js: '6'
+    - node_js: '6'
       os: linux
-    - env: CXX=g++-4.9
-      node_js: '5'
+    - node_js: '5'
       os: linux
-    - env: CXX=g++-4.9
-      node_js: '4'
+    - node_js: '4'
       os: linux
-    - env: CXX=g++-4.9
-      node_js: '6'
+    - node_js: '6'
       os: osx
-    - env: CXX=g++-4.9
-      node_js: '5'
+    - node_js: '5'
       os: osx
-    - env: CXX=g++-4.9
-      node_js: '4'
+    - node_js: '4'
       os: osx

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "eslint src",
     "prepublish": "del-cli dist && cross-env BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "report": "nyc report --reporter=html",
-    "test": "cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 nyc --check-coverage --lines 95 ava"
+    "test": "cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 nyc --check-coverage --lines 100 ava"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "eslint src",
     "prepublish": "del-cli dist && cross-env BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "report": "nyc report --reporter=html",
-    "test": "cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 nyc --check-coverage --lines 100 ava"
+    "test": "cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 nyc --check-coverage --lines 95 ava"
   },
   "engines": {
     "node": ">=4"
@@ -35,9 +35,7 @@
   "repository": "ben-eb/postcss-resemble-image",
   "license": "MIT",
   "dependencies": {
-    "asset-resolver": "^0.3.0",
-    "image-size": "^0.5.0",
-    "paper": "^0.10.2",
+    "jimp": "^0.2.27",
     "postcss": "^5.2.5",
     "postcss-value-parser": "^3.3.0"
   },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -7,6 +7,7 @@ import valueParser from 'postcss-value-parser';
 import plugin, {complexGradient, simpleGradient} from '..';
 
 const image = './../../docs/waves.jpg';
+const unprocessable = './../../docs/index.html';
 
 function getArguments (node) {
     return node.nodes.reduce((list, child) => {
@@ -159,4 +160,16 @@ test(
     'should error on invalid fidelity',
     shouldThrow,
     `header{background:resemble-image(url("${image}"), twenty-five)}`
+);
+
+test(
+    'should error on non-existing image',
+    shouldThrow,
+    `header{background:resemble-image(url(), twenty-five)}`
+);
+
+test(
+    'should error on unprocessable image',
+    shouldThrow,
+    `header{background:resemble-image(url("${unprocessable}"), twenty-five)}`
 );

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -171,5 +171,5 @@ test(
 test(
     'should error on unprocessable image',
     shouldThrow,
-    `header{background:resemble-image(url("${unprocessable}"), twenty-five)}`
+    `header{background:resemble-image(url("${unprocessable}"))}`
 );

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -26,7 +26,12 @@ function assertColourStops (t, fixture, expected, options) {
             if (node.value !== 'linear-gradient') {
                 return false;
             }
-            t.deepEqual(getArguments(node).slice(1).length, expected);
+            const stops = getArguments(node).slice(1);
+            t.deepEqual(stops.length, expected);
+            stops.forEach(stop => {
+                const colour = stop[0].value;
+                t.truthy(/^#[0-9a-f]{6}$/i.test(colour));
+            });
         });
     });
 }

--- a/src/resembleImage.js
+++ b/src/resembleImage.js
@@ -35,7 +35,7 @@ function rgbToHex ({r, g, b}) {
         const hex = c.toString(16);
         return hex.length === 1 ? '0' + hex : hex;
     }
-    return convert(r) + convert(g) + convert(b);
+    return '#' + convert(r) + convert(g) + convert(b);
 }
 
 export default function resembleImage (path, {generator, fidelity}) {

--- a/src/resembleImage.js
+++ b/src/resembleImage.js
@@ -44,19 +44,20 @@ export default function resembleImage (path, {generator, fidelity}) {
             if (err) {
                 reject(err);
             }
-            const width = image.bitmap.width;
-            const height = image.bitmap.height;
-            const stops = [];
-            const colourStop = colourStopFactory(width);
+            let width;
+            let height;
             let chunk;
-            let color;
             try {
+                width = image.bitmap.width;
+                height = image.bitmap.height;
                 chunk = resolveFidelity(width, fidelity);
             } catch (e) {
                 return reject(e);
             }
+            const stops = [];
+            const colourStop = colourStopFactory(width);
             for (let i = 0; i < width; i += chunk) {
-                color = image.clone()
+                let color = image.clone()
                     .crop(i, 0, chunk, height)
                     .resize(1, 1, Jimp.RESIZE_BICUBIC)
                     .getPixelColor(0, 0);


### PR DESCRIPTION
These changes address #1. 

I replaced `asset-resolver`, `image-size` and `paper` with a single dependency to `jimp`. Wasn't able to get 100% test coverage though… any ideas on that?