### PR TITLE
Move fallback gradient output to the end

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -39,6 +39,12 @@ function assertColourStops (t, fixture, expected, options) {
     });
 }
 
+function shouldNotHaveFunctionInOutput (t, fixture, expected, options) {
+    return postcss(plugin(options)).process(fixture).then((result) => {
+        t.is(result.root.first.nodes[0].value.indexOf('resemble-image'), -1);
+    });
+}
+
 function processCss (t, fixture, expected, options) {
     return postcss(plugin(options)).process(fixture).then(({css}) => {
         t.deepEqual(css, expected);
@@ -77,6 +83,13 @@ test(
     `header, footer{background:url("${image}")}`,
     4,
     {selectors: ['header']}
+);
+
+test(
+    'should output a value without the resemble-image() function wrapped around',
+    shouldNotHaveFunctionInOutput,
+    `header{background:resemble-image(url("${image}"))}`,
+    4
 );
 
 test(
@@ -149,6 +162,12 @@ test(
     'should handle multiple backgrounds',
     assertColourStops,
     `header{background:url("foo.jpg"), resemble-image(url("${image}"))}`,
+    4
+);
+
+test('should handle background value shorthand',
+    assertColourStops,
+    `header{background:resemble-image(url("${image}")) no-repeat center / cover}`,
     4
 );
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -171,6 +171,15 @@ test('should handle background value shorthand',
     4
 );
 
+test('should handle background value shorthand', t => {
+    const fixture = `header{background:resemble-image(url("${image}")) no-repeat center / cover}`;
+    return postcss(plugin()).process(fixture).then((result) => {
+        // Check if the fallback gradient is appended at the end of the value
+        t.not(result.root.first.nodes[0].value.match(/linear-gradient\([^)]+\)$/), null);
+        return assertColourStops(t, fixture, 4);
+    });
+});
+
 test(
     'should error on 0',
     shouldThrow,

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function resemblePromise (decl, opts, wrapped = true) {
     let url;
     let toString;
 
-    decl.value = valueParser(decl.value).walk(node => {
+    decl.value = valueParser(decl.value).walk((node, index, nodes) => {
         const {type, value} = node;
         if (type !== 'function') {
             return false;
@@ -44,8 +44,16 @@ function resemblePromise (decl, opts, wrapped = true) {
                     fidelity,
                 }
             ).then(gradient => {
-                node.value = stringify(toString) + ', ' + gradient;
+                // Remove the resemble-image function wrapper if there is any
+                node.value = stringify(toString);
                 node.type = 'word';
+
+                // Add the gradient at the end of the value
+                nodes.push({
+                    type: 'word',
+                    value: `, ${gradient}`,
+                    after: true,
+                });
             })
         );
         return false;


### PR DESCRIPTION
Fixes #8. Thanks for sorting out what to do to fix it really quickly!

I've also added a test, but we might need a test to check if the gradient is added at the end. I've also added another test to check if `resemble-image()` is removed in the output.